### PR TITLE
make tokenizr external for browser builds

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,9 @@ module.exports = function (grunt) {
                         [ "browserify-derequire" ],
                         [ "browserify-header" ]
                     ],
+                    external: [
+                        "tokenizr"
+                    ],
                     browserifyOptions: {
                         standalone: "GraphQLQueryCompress",
                         debug: true


### PR DESCRIPTION
Hi - me again - sorry to bother.  This is a tiny tweak to make tokenizr external in the browser build.  By default you're bundling all of tokenizr inside of your bundle. This means that if I'm using this library, and I'm also using tokenizr directly in my web app, webpack will wind up bundling two identical copies of tokenizr.

By making this external, webpack can now be smart enough to only include a single copy of tokenizr in my bundle.

Of course this means you now need a build step; you wouldn't be able to run this with just a script tag. No hard feelings if you're not ok with that - it would be pretty easy for me to alias this library to the node build; but I do think this would be a more sensible default in this day and age. 