### PR TITLE
make entry point consistently CJS instead of ESM and CJS combined

### DIFF
--- a/src/graphql-query-compress.js
+++ b/src/graphql-query-compress.js
@@ -23,7 +23,7 @@
 */
 
 /*  external dependency  */
-import Tokenizr from "tokenizr"
+const Tokenizr = require("tokenizr");
 
 /*  the API function: compress a GraphQL query string  */
 function compactGraphQLQuery (query) {


### PR DESCRIPTION
Sorry for all the GitHub notifications. Your entry point was a mix of ESM for import, and CJS for export. This causes errors if people alias webpack to just consume the entry point directly. Making the entry point consistently CJS fixes this problem, without introducing any breaking behavior.